### PR TITLE
Prevent contents of hint boxes from overflowing

### DIFF
--- a/resources/compile_quiz.py
+++ b/resources/compile_quiz.py
@@ -73,7 +73,7 @@ SHOW_WORKINGS = False
 SHOW_EXPLANATION = False
 
 def add_hint_comment(ctype, comment):
-  colour_box = '<p style="border-style:solid; border-width:5px; border-color:#ff0000 #0000ff;">%s:<br>%s</p><hr>'
+  colour_box = '<div style="border-style:solid; border-width:5px; border-color:#ff0000 #0000ff;">%s:<br>%s</div><hr>'
   if ctype == 'c':
     return colour_box % ("comment", comment)
   elif ctype == 'h':


### PR DESCRIPTION
Since `<p>` tags can't be nested, contents that contained `<p>` tags
would overflow, by changing the coloured box to using a `<div>` we
support arbitrary nested HTML